### PR TITLE
Call correct error function for customer not found

### DIFF
--- a/project/bank/service/customer_service.go
+++ b/project/bank/service/customer_service.go
@@ -41,7 +41,7 @@ func (s customerService) GetCustomer(id int) (*CustomerResponse, error) {
 	if err != nil {
 
 		if err == sql.ErrNoRows {
-			return nil, errs.NewValidationError("customer not found")
+			return nil, errs.NewNotFoundError("customer not found")
 		}
 
 		logs.Error(err)


### PR DESCRIPTION
Great job, @codebangkok. Thanks for sharing.

In this PR, I corrected the following issue: the `GetCustomer` method was calling `NewValidationError` function when no customer was found. However, the correct function to be called is the `NewNotFoundError`. 